### PR TITLE
render the rel['firstimage'] metadata when not already set

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -151,7 +151,6 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
             $R->doc .= $this->_gallery($data);
             return true;
         }elseif($mode == 'metadata'){
-            $files = $this->_findimages($data);
             $rel = p_get_metadata($ID,'relation',METADATA_RENDER_USING_CACHE);
             $img = $rel['firstimage'];
             if(empty($img)){


### PR DESCRIPTION
Render the `firstimage` metadata when not already set in the page.

This is useful when using eg. the _socialcards_ plugin which renders opengraph and twitter metadata.
