### PR TITLE
Never enable already disabled caching, fixes #84

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -147,7 +147,7 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
     function render($mode, Doku_Renderer $R, $data){
         global $ID;
         if($mode == 'xhtml'){
-            $R->info['cache'] = $data['cache'];
+            $R->info['cache'] &= $data['cache'];
             $R->doc .= $this->_gallery($data);
             return true;
         }elseif($mode == 'metadata'){


### PR DESCRIPTION
When another plugin or the `~~NOCACHE~~`-syntax disabled caching, the gallery plugin previously re-enabled caching again. With this change, the plugin only disables caching when requested, but never re-enables caching.