### PR TITLE
Add ability to specify a list of pictures

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -273,7 +273,7 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
                     'detail' => $url
                 );
             } else {
-                $files = array_combine($files,$this->_findImagesFromNS($url, $conf['mediadir'], $data['recursive']));
+                $files = array_merge($files,$this->_findImagesFromNS($url, $conf['mediadir'], $data['recursive']));
             }
         }
         return $files;

--- a/syntax.php
+++ b/syntax.php
@@ -6,6 +6,7 @@
  * @author     Andreas Gohr <andi@splitbrain.org>
  * @author     Joe Lapp <joe.lapp@pobox.com>
  * @author     Dave Doyle <davedoyle.canadalawbook.ca>
+ * @author     BilliAlpha (http://billi-dot.pe.hu)
  */
 
 if(!defined('DOKU_INC')) define('DOKU_INC',realpath(dirname(__FILE__).'/../../').'/');
@@ -66,12 +67,12 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
         $ns = trim($ns);
 
         // namespace (including resolving relatives)
-        if(!preg_match('/^https?:\/\//i',$ns)){
-            $data['ns'] = resolve_id(getNS($ID),$ns);
-        } else if ($ns==='') {
+        if(preg_match('/^https?:\/\//i',$ns)){
+            $data['ns'] =  $ns;
+        } else if (!strlen($ns)) {
             $data['ns'] = 'USE_EXTERNAL_IMAGE_LIST';
         } else {
-            $data['ns'] =  $ns;
+            $data['ns'] = resolve_id(getNS($ID),$ns);
         }
 
         // set the defaults
@@ -235,7 +236,7 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
      */
     function _findImagesFromNS($ns, $mediadir, $recursive=false) {
         $files = array();
-        $dir = utf8_encodeFN(str_replace(':','/',$ns);
+        $dir = utf8_encodeFN(str_replace(':','/',$ns));
         // all possible images for the given namespace (or a single image)
         if(is_file($mediadir.'/'.$dir)){
             require_once(DOKU_INC.'inc/JpegMeta.php');


### PR DESCRIPTION
In case you would want to create a gallery from pictures and do not have an RSS feed for them nor want to upload them to your server, this allows you to give a list of pictures (local or external).
This is kind of what was asked in issue #69.
This also resembles issue #16.
Should probably be used with #103 in order to keep aspect-ratio of the pictures without having to download the picture in order to figure out the dimensions (which would drastically slow the loading time down).

Sorry if this does not fit the purpose of this plugin, I thought it might be usefull.