### PR TITLE
Combine images from many namespaces/files/rss

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -3,13 +3,16 @@
  * Options for the gallery plugin
  *
  * @author Dmitry Baikov <dsbaikov@gmail.com>
+ * @author Piotr Gapinski <pijoter@hardwired>
  */
 
-$conf['thumbnail_width']  = 120;
-$conf['thumbnail_height'] = 120;
-$conf['image_width']      = 800;
-$conf['image_height']     = 600;
-$conf['cols']             = 5;
+$conf['thumbnail_width']  = 200;
+$conf['thumbnail_height'] = 200;
+//$conf['image_width']      = 800;
+//$conf['image_height']     = 600;
+$conf['cols']             = 0;
+$conf['paginate']         = 0;
+$conf['limit']            = 12;
 
 $conf['sort'] = 'file';
-$conf['options'] = 'cache';
+$conf['options'] = 'cache&lightbox&crop&recursive';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -10,7 +10,9 @@ $meta['thumbnail_height'] = array('numeric');
 $meta['image_width']      = array('numeric');
 $meta['image_height']     = array('numeric');
 $meta['cols']             = array('numeric');
+$meta['paginate']         = array('numeric');
+$meta['limit']            = array('numeric');
 
 $meta['sort']    = array('multichoice', '_choices' => array('file','mod','date','title'));
-$meta['options'] = array('multicheckbox', '_choices' => array('cache','crop','direct','lightbox','random','reverse','showname','showtitle'));
+$meta['options'] = array('multicheckbox', '_choices' => array('cache','crop','direct','lightbox','random','reverse','recursive','showname','showtitle'));
 

--- a/syntax.php
+++ b/syntax.php
@@ -178,7 +178,7 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
     function render($mode, Doku_Renderer $R, $data){
         global $ID;
         if($mode == 'xhtml'){
-            $R->info['cache'] = $data['cache'];
+            $R->info['cache'] &= $data['cache'];
             $R->doc .= $this->_gallery($data);
             return true;
         }elseif($mode == 'metadata'){


### PR DESCRIPTION
 - include/exclude files from several namespaces or rss;
 - images could have their own title (take precedence over meta-title);
 - images are aligned to the left by default;
 - paginate menu will be shown only when there are more than one page of images;
 - rss urls are not parsed so could use '?' and '&' for their own purposes;
 - because urls can countains '?' and '&' there is no way to pass additional gallery params;
 - per gallery options can be overridden by params passed in every namespace;
 - additional params: left,right,center

syntax:

{{gallery>namespace?some&params}}
{{gallery> namespace}} -> aligned to the right
...

or

{{gallery>
namespace?some&params
+other:namespace:image.jpg|optional title
-my:namespace
-their:namespace:image.jpg
}}

or
&lt;gallery&gt;
{{namespace?some&params}}
{{my:namespace:image.jpg}}
&lt;/gallery&gt;

Pijoter.