### PR TITLE
Fix pagination if not multiple of column count

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -403,7 +403,7 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
                 $ret .= '</td>';
                 $i++;
 
-                // done with this row? cloase it
+                // done with this row? close it
                 $close_tr = true;
                 if($i % $data['cols'] == 0){
                     $ret .= '</tr>';
@@ -423,9 +423,10 @@ class syntax_plugin_gallery extends DokuWiki_Syntax_Plugin {
                     $ret .= '</table>';
                     $ret .= '</div>';
                     $close_pg = false;
+                    $i = 0; // reset counter to ensure next page is properly started
                 }
 
-            }
+            } // foreach
 
             if ($close_tr){
                 // add remaining empty cells


### PR DESCRIPTION
If pagination count and column count are not multiples of each other, then the count needs to be
reset for the start of a new page to properly add the starting tags

Closes #81